### PR TITLE
fix: Vercel annoyingly only supports daily free cron jobs, updating to use Upstash instead!

### DIFF
--- a/DEPLOYMENT_CHECKLIST.md
+++ b/DEPLOYMENT_CHECKLIST.md
@@ -166,6 +166,33 @@ vercel env pull .env
 yarn db:migrate
 ```
 
+#### **Step 5: Setup QStash Schedules**
+
+```bash
+# Update API_URL with your actual Vercel domain
+# Edit .env file and change API_URL to your real domain
+# Example: API_URL=https://your-project.vercel.app
+
+# Setup QStash schedules
+yarn qstash:setup
+```
+
+**What this does:**
+
+- Creates a schedule that runs every 5 minutes for processing scheduled jobs
+- Creates a schedule that runs daily at 2 AM for cleaning up old jobs
+- Both schedules point to your API endpoint: `/api/jobs/process-immediate`
+
+**To check your schedules:**
+
+```bash
+# List all schedules
+curl -H "Authorization: Bearer $UPSTASH_QSTASH_TOKEN" https://qstash.upstash.io/v2/schedules | jq .
+
+# Or visit the Upstash Console
+# https://console.upstash.com/qstash
+```
+
 ---
 
 ### **Method 2: Vercel UI Deployment**

--- a/ENVIRONMENT_VARIABLES_GUIDE.md
+++ b/ENVIRONMENT_VARIABLES_GUIDE.md
@@ -106,12 +106,24 @@ and their specific purposes.
 
 ### **UPSTASH_QSTASH_TOKEN**
 
-- **Purpose**: Token for Upstash QStash real-time job processing
+- **Purpose**: Token for Upstash QStash real-time job processing and scheduled
+  jobs
 - **How to Get**:
   1. Go to [Upstash Console](https://console.upstash.com)
   2. Create a new QStash database
   3. Copy the token from the dashboard
-- **Usage**: Processes real-time jobs like Slack messages, notifications
+- **Usage**:
+  - Processes real-time jobs like Slack messages, notifications
+  - Handles scheduled jobs (every minute processing, daily cleanup)
+  - **To check your schedules**:
+
+    ```bash
+    # List all schedules
+    curl -H "Authorization: Bearer $UPSTASH_QSTASH_TOKEN" https://qstash.upstash.io/v2/schedules | jq .
+
+    # Or visit the Upstash Console
+    # https://console.upstash.com/qstash
+    ```
 
 ### **UPSTASH_QSTASH_CURRENT_SIGNING_KEY** & **UPSTASH_QSTASH_NEXT_SIGNING_KEY**
 
@@ -483,6 +495,34 @@ and their specific purposes.
 5. ✅ Email Service (Postmark)
 6. ✅ Slack Integration
 7. ✅ Error Tracking (Sentry)
+
+### **QStash Schedule Setup:**
+
+After deployment, run the following to setup scheduled jobs:
+
+```bash
+# Update API_URL with your actual Vercel domain
+# Edit .env file and change API_URL to your real domain
+# Example: API_URL=https://your-project.vercel.app
+
+# Setup QStash schedules
+yarn qstash:setup
+```
+
+**This creates:**
+
+- **Every 5 minutes**: Processes scheduled jobs
+- **Daily at 2 AM**: Cleans up old jobs
+
+**To check your schedules:**
+
+```bash
+# List all schedules
+curl -H "Authorization: Bearer $UPSTASH_QSTASH_TOKEN" https://qstash.upstash.io/v2/schedules | jq .
+
+# Or visit the Upstash Console
+# https://console.upstash.com/qstash
+```
 
 ### **Optional Features:**
 

--- a/QSTASH_GUIDE.md
+++ b/QSTASH_GUIDE.md
@@ -1,0 +1,157 @@
+# QStash Setup & Monitoring Guide
+
+## 🚀 Quick Setup
+
+### 1. Create QStash Project
+
+1. Go to [Upstash Console](https://console.upstash.com)
+2. Create a new QStash database
+3. Copy your token and signing keys
+
+### 2. Add Environment Variables
+
+```bash
+# Add to your .env file
+UPSTASH_QSTASH_TOKEN="your_qstash_token"
+UPSTASH_QSTASH_CURRENT_SIGNING_KEY="your_signing_key"
+UPSTASH_QSTASH_NEXT_SIGNING_KEY="your_next_signing_key"
+```
+
+### 3. Setup Schedules
+
+```bash
+# Update API_URL with your actual Vercel domain
+# Edit .env file and change API_URL to your real domain
+# Example: API_URL=https://your-project.vercel.app
+
+# Setup QStash schedules
+yarn qstash:setup
+```
+
+## 📋 What Gets Created
+
+### Schedule 1: Every 5 Minutes Processing
+
+- **Cron**: `*/5 * * * *`
+- **Job**: `scheduled.job.process`
+- **Purpose**: Processes scheduled jobs from the database
+- **Endpoint**: `/api/jobs/process-immediate`
+
+### Schedule 2: Daily Cleanup
+
+- **Cron**: `0 2 * * *` (2 AM daily)
+- **Job**: `cleanup.old.jobs`
+- **Purpose**: Cleans up old completed jobs
+- **Endpoint**: `/api/jobs/process-immediate`
+
+## 🔍 Monitoring Your Schedules
+
+### Method 1: Command Line
+
+```bash
+# List all schedules
+curl -H "Authorization: Bearer $UPSTASH_QSTASH_TOKEN" https://qstash.upstash.io/v2/schedules | jq .
+
+# Check specific schedule
+curl -H "Authorization: Bearer $UPSTASH_QSTASH_TOKEN" https://qstash.upstash.io/v2/schedules/SCHEDULE_ID
+
+# Check message history
+curl -H "Authorization: Bearer $UPSTASH_QSTASH_TOKEN" https://qstash.upstash.io/v2/messages
+```
+
+### Method 2: Upstash Console (Recommended)
+
+Visit: **https://console.upstash.com/qstash**
+
+Features:
+
+- ✅ View all schedules
+- ✅ See execution history
+- ✅ Check message status
+- ✅ Pause/resume schedules
+- ✅ View logs and errors
+- ✅ Real-time monitoring
+
+## 🔧 Troubleshooting
+
+### Common Issues
+
+1. **"Invalid token" error**
+   - Check that `UPSTASH_QSTASH_TOKEN` is set correctly
+   - Verify the token in your Upstash console
+
+2. **Schedules not running**
+   - Check that your API endpoint is accessible
+   - Verify the webhook signature verification
+   - Check your API logs for errors
+
+3. **Jobs not being processed**
+   - Ensure your database has scheduled jobs
+   - Check that the job processing logic is working
+   - Verify the API endpoint returns 200 status
+
+### Debug Commands
+
+```bash
+# Test your API endpoint
+curl -X POST https://your-api.vercel.app/api/jobs/process-immediate \
+  -H "Content-Type: application/json" \
+  -d '{"name":"test","data":{}}'
+
+# Check QStash webhook signature
+# (This is handled automatically by the API)
+```
+
+## 📊 Understanding the Response
+
+When you list schedules, you'll see:
+
+```json
+{
+  "scheduleId": "scd_5RLBWxdLydTNr99CiaTBCRb6UtrU",
+  "cron": "* * * * *",
+  "destination": "https://your-api.vercel.app/api/jobs/process-immediate",
+  "lastScheduleTime": 1754288640041,
+  "nextScheduleTime": 1754288700000,
+  "lastScheduleStates": {
+    "msg_26hZCxZCuWyyTWPmSVBrNB882AMa7DriCTjoV3p8QUWiQCnosbnAi2qjm5MEwr1": "IN_PROGRESS"
+  },
+  "isPaused": false
+}
+```
+
+**Key fields:**
+
+- `scheduleId`: Unique identifier for the schedule
+- `cron`: The schedule pattern
+- `destination`: Where the job is sent
+- `lastScheduleTime`: When it last ran
+- `nextScheduleTime`: When it will run next
+- `lastScheduleStates`: Status of recent executions
+- `isPaused`: Whether the schedule is paused
+
+## 🔄 Updating Schedules
+
+If you need to update your API URL:
+
+1. **Delete old schedules** (via Upstash Console)
+2. **Update your API_URL** in `.env`
+3. **Re-run setup**:
+   ```bash
+   yarn qstash:setup
+   ```
+
+## 🎯 Best Practices
+
+1. **Monitor regularly**: Check the Upstash Console weekly
+2. **Set up alerts**: Configure notifications for failed jobs
+3. **Test endpoints**: Verify your API endpoints work before setting up
+   schedules
+4. **Keep tokens secure**: Never commit tokens to version control
+5. **Document changes**: Update this guide when making changes
+
+## 📞 Support
+
+- **Upstash Documentation**: https://docs.upstash.com/qstash
+- **Upstash Console**: https://console.upstash.com/qstash
+- **API Reference**: https://docs.upstash.com/qstash/api

--- a/VERCEL_DEPLOYMENT.md
+++ b/VERCEL_DEPLOYMENT.md
@@ -200,6 +200,33 @@ vercel env pull .env
 yarn db:migrate
 ```
 
+### 5. Setup QStash Schedules
+
+```bash
+# Update API_URL with your actual Vercel domain
+# Edit .env file and change API_URL to your real domain
+# Example: API_URL=https://your-project.vercel.app
+
+# Setup QStash schedules
+yarn qstash:setup
+```
+
+**What this does:**
+
+- Creates a schedule that runs every 5 minutes for processing scheduled jobs
+- Creates a schedule that runs daily at 2 AM for cleaning up old jobs
+- Both schedules point to your API endpoint: `/api/jobs/process-immediate`
+
+**To check your schedules:**
+
+```bash
+# List all schedules
+curl -H "Authorization: Bearer $UPSTASH_QSTASH_TOKEN" https://qstash.upstash.io/v2/schedules | jq .
+
+# Or visit the Upstash Console
+# https://console.upstash.com/qstash
+```
+
 ## Development
 
 For local development, you can still use the original Docker setup:

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint:fix": "turbo run lint:fix --cache-dir=.turbo",
     "prisma:setup": "yarn workspace @hackcommunity/scripts prisma:setup",
     "prisma:studio": "yarn workspace @hackcommunity/db prisma:studio",
+    "qstash:setup": "tsx scripts/setup-qstash-schedules.ts",
     "start": "turbo run start --cache-dir=.turbo",
     "start:vercel": "node apps/member-profile/build/server/index.js",
     "test": "turbo run test --cache-dir=.turbo",

--- a/scripts/setup-qstash-schedules.ts
+++ b/scripts/setup-qstash-schedules.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+import { config } from 'dotenv';
+import { Client as QStashClient } from '@upstash/qstash';
+
+// Load environment variables from .env file
+config();
+
+// Environment variables
+const UPSTASH_QSTASH_TOKEN = process.env.UPSTASH_QSTASH_TOKEN;
+const API_URL = process.env.API_URL;
+
+if (!UPSTASH_QSTASH_TOKEN) {
+  console.error('❌ UPSTASH_QSTASH_TOKEN is required');
+  console.error('💡 Set it in your .env file or export it in your terminal');
+  process.exit(1);
+}
+
+if (!API_URL) {
+  console.error('❌ API_URL is required');
+  console.error('💡 Set it in your .env file or export it in your terminal');
+  process.exit(1);
+}
+
+const qstash = new QStashClient({
+  token: UPSTASH_QSTASH_TOKEN,
+});
+
+async function setupQStashSchedules() {
+  console.log('🚀 Setting up QStash schedules...');
+
+  try {
+    // 1. Scheduled Job Processing (every 5 minutes)
+    console.log(
+      '📅 Creating scheduled job processing schedule (every 5 minutes)...'
+    );
+    await qstash.schedules.create({
+      destination: `${API_URL}/api/jobs/process-immediate`,
+      cron: '*/5 * * * *', // Every 5 minutes
+      body: JSON.stringify({
+        name: 'scheduled.job.process',
+        data: { action: 'process_scheduled_jobs' },
+      }),
+    });
+    console.log('✅ Scheduled job processing schedule created');
+
+    // 2. Cleanup Old Jobs (daily at 2 AM)
+    console.log('🧹 Creating cleanup old jobs schedule (daily at 2 AM)...');
+    await qstash.schedules.create({
+      destination: `${API_URL}/api/jobs/process-immediate`,
+      cron: '0 2 * * *', // Daily at 2 AM
+      body: JSON.stringify({
+        name: 'cleanup.old.jobs',
+        data: { action: 'cleanup_old_jobs' },
+      }),
+    });
+    console.log('✅ Cleanup old jobs schedule created');
+
+    console.log('🎉 All QStash schedules created successfully!');
+    console.log('');
+    console.log('📋 Summary:');
+    console.log('  • Scheduled job processing: Every 5 minutes');
+    console.log('  • Cleanup old jobs: Daily at 2 AM');
+    console.log('');
+    console.log(
+      '🔗 You can view your schedules at: https://console.upstash.com/qstash'
+    );
+  } catch (error) {
+    console.error('❌ Failed to create QStash schedules:', error);
+    process.exit(1);
+  }
+}
+
+setupQStashSchedules();

--- a/vercel.json
+++ b/vercel.json
@@ -27,15 +27,5 @@
   ],
   "env": {
     "NODE_ENV": "production"
-  },
-  "crons": [
-    {
-      "path": "/api/jobs/process",
-      "schedule": "* * * * *"
-    },
-    {
-      "path": "/api/cron/cleanup-old-jobs",
-      "schedule": "0 2 * * *"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
…ry min so updating to try to use qstash for this

## Description ✏️

Closes #xxx

Describe what this PR does.

- Removes Vercel cron jobs (limited to daily on free tier)
- Adds QStash schedules (every minute + daily cleanup)
- Creates setup script (`yarn qstash:setup`) for easy deployment
- Updates documentation with monitoring guides and troubleshooting

## Type of Change 🐞

- [ ] Feature - A non-breaking change which adds functionality.
- [x] Fix - A non-breaking change which fixes an issue.
- [x] Refactor - A change that neither fixes a bug nor adds a feature.
- [x] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
- [x] I have added/updated any relevant documentation (if applicable).
